### PR TITLE
fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ``` bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:3000
 $ npm run dev


### PR DESCRIPTION
`npm run install` gives the following output:

npm ERR! missing script: install

npm ERR! A complete log of this run can be found in:
...

The right command is just `npm install`