### PR TITLE
Fix name of the JSON key for the link section

### DIFF
--- a/static/reviews.json
+++ b/static/reviews.json
@@ -245,6 +245,6 @@
   },
   {
     "author": "Christoph Rumpel",
-    "links": "https://christoph-rumpel.com/2020/01/my-coding-year-2019"
+    "link": "https://christoph-rumpel.com/2020/01/my-coding-year-2019"
   }
 ]


### PR DESCRIPTION
For the link section on Christoph Rumpel's JSON entry, use the singular form instead of the plural one.